### PR TITLE
add format prefix to temporary file's name

### DIFF
--- a/libs/ImageResizer.js
+++ b/libs/ImageResizer.js
@@ -36,7 +36,7 @@ class ImageResizer {
     exec(image) {
         const tmpobj = tmp.fileSync();
         const params = {
-            srcPath: tmpobj.name,
+            srcPath: image.type + ":" + tmpobj.name,
             srcFormat: image.type,
             format:    image.type
         };

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "author": "Yoshiaki Sugimoto",
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "2.3.9",
+    "aws-sdk": "^2.656.0",
     "imagemagick": "git://github.com/jrochel/node-imagemagick.git#besport",
-    "lodash": "4.12.0",
+    "lodash": "^4.17.15",
     "tmp": "0.0.33"
   },
   "devDependencies": {


### PR DESCRIPTION
node-imagemagick only adds the prefix if input comes from stdin